### PR TITLE
Add derived exception typeclasses to handler transformer

### DIFF
--- a/src/Routes/Handler.hs
+++ b/src/Routes/Handler.hs
@@ -80,6 +80,7 @@ import Control.Monad.State (StateT, get, put, modify, runStateT, MonadState, Mon
 import Control.Arrow ((***))
 import Control.Applicative (Applicative, (<$>), (<*>))
 
+import qualified Control.Exception.Safe as EX
 import Data.Maybe (fromMaybe)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
@@ -114,7 +115,7 @@ import qualified Network.Wai.Parse as P
 -- | The internal implementation of the HandlerM monad
 -- TODO: Should change this to StateT over ReaderT (but performance may suffer)
 newtype HandlerMI sub master m a = H { extractH :: StateT (HandlerState sub master) m a }
-    deriving (Applicative, Monad, MonadIO, Functor, MonadTrans, MonadState (HandlerState sub master))
+    deriving (Applicative, Monad, MonadIO, Functor, MonadTrans, MonadState (HandlerState sub master), EX.MonadThrow, EX.MonadCatch, EX.MonadMask)
 
 -- | The HandlerM Monad
 type HandlerM sub master a = HandlerMI sub master IO a

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,4 +16,5 @@ extra-deps:
 - digestive-functors-0.8.3.0
 - digestive-functors-blaze-0.6.2.0
 - http-types-0.12.1
+- safe-exceptions-0.1.7.0
 resolver: lts-11.9

--- a/wai-routes.cabal
+++ b/wai-routes.cabal
@@ -44,6 +44,7 @@ library
                        , cookie             >= 0.4  && < 0.5
                        , data-default-class >= 0.0  && < 0.2
                        , vault              >= 0.3  && < 0.4
+                       , safe-exceptions    >= 0.1.0.0 && < 0.2
     exposed-modules    : Wai.Routes, Network.Wai.Middleware.Routes
     other-modules      : Routes.Parse
                          Routes.Overlap


### PR DESCRIPTION
Without this, the only way to catch exceptions in handlers is to lift
your own operations into IO. This forces you to catch exceptions at
each individual computation and pass them upwards to deal with them,
which is not always practical to do. In my own initial tests, this seems to work well.