### PR TITLE
Allow newer versions of template-haskell

### DIFF
--- a/src/Routes/Routes.hs
+++ b/src/Routes/Routes.hs
@@ -25,7 +25,10 @@ module Routes.Routes
 
     -- * Template Haskell methods
     , mkRoute
+    , mkRouteData
+    , mkRouteDispatch
     , mkRouteSub
+    , mkRouteSubDispatch
 
     -- * Dispatch
     , routeDispatch

--- a/src/Routes/TH/RenderRoute.hs
+++ b/src/Routes/TH/RenderRoute.hs
@@ -67,7 +67,11 @@ mkRenderRouteClauses =
         let cnt = length $ filter isDynamic pieces
         dyns <- replicateM cnt $ newName "dyn"
         child <- newName "child"
+#if MIN_VERSION_template_haskell(2,18,0)
+        let pat = ConP (mkName name) [] $ map VarP $ dyns ++ [child]
+#else
         let pat = ConP (mkName name) $ map VarP $ dyns ++ [child]
+#endif
 
         pack' <- [|pack|]
         tsp <- [|toPathPiece|]
@@ -100,7 +104,11 @@ mkRenderRouteClauses =
             case resourceDispatch res of
                 Subsite{} -> return <$> newName "sub"
                 _ -> return []
+#if MIN_VERSION_template_haskell(2,18,0)
+        let pat = ConP (mkName $ resourceName res) [] $ map VarP $ dyns ++ sub
+#else
         let pat = ConP (mkName $ resourceName res) $ map VarP $ dyns ++ sub
+#endif
 
         pack' <- [|pack|]
         tsp <- [|toPathPiece|]

--- a/src/Routes/TH/RouteAttrs.hs
+++ b/src/Routes/TH/RouteAttrs.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE CPP #-}
 module Routes.TH.RouteAttrs
     ( mkRouteAttrsInstance
     ) where
@@ -26,7 +27,11 @@ goTree front (ResourceParent name _check pieces trees) =
     toIgnore = length $ filter isDynamic pieces
     isDynamic Dynamic{} = True
     isDynamic Static{} = False
+#if MIN_VERSION_template_haskell(2,18,0)
+    front' = front . ConP (mkName name) [] . ignored
+#else
     front' = front . ConP (mkName name) . ignored
+#endif
 
 goRes :: (Pat -> Pat) -> Resource a -> Q Clause
 goRes front Resource {..} =

--- a/src/Wai/Routes.hs
+++ b/src/Wai/Routes.hs
@@ -17,7 +17,10 @@ module Wai.Routes
     , parseRoutesFileNoCheck -- | Same as parseRoutesFile, but performs no overlap checking.
 
     , mkRoute
+    , mkRouteData
+    , mkRouteDispatch
     , mkRouteSub
+    , mkRouteSubDispatch
 
     -- * Dispatch
     , routeDispatch

--- a/wai-routes.cabal
+++ b/wai-routes.cabal
@@ -1,5 +1,5 @@
 name               : wai-routes
-version            : 0.10.4
+version            : 0.10.5
 cabal-version      : 1.18
 build-type         : Simple
 license            : MIT
@@ -14,14 +14,9 @@ author             : Anupam Jain
 data-dir           : ""
 extra-source-files : README.md
 
-source-repository head
-    type     : git
-    location : http://github.com/ajnsit/wai-routes
-
 source-repository this
     type     : git
-    location : http://github.com/ajnsit/wai-routes/tree/v0.10.4
-    tag      : v0.10.4
+    location : http://github.com/ajnsit/wai-routes
 
 library
     build-depends      : base


### PR DESCRIPTION
Also export `mkRouteData`, `mkRouteDispatch` and `mkRouteSubDispatch` to allow separation of the data type from the routable instance.

Bump the version while we're at it, as there are new features exposed.

I'm not so certain about the changes to the cabal file, feel free to make suggestions or edits.

Also, I suspect it would be better to bump the version in a separate commit. Just let me know.